### PR TITLE
[BUGFIX] Keep GitHub actions on Composer 1 (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install composer dependencies"
         run: |
-          composer install --no-ansi --no-interaction --no-progress --no-suggest
+          composer selfupdate --1
+          composer install --no-ansi --no-interaction --no-progress
           composer show
       - name: "Run tests"
         run: "composer ci:tests:unit"
@@ -88,7 +89,8 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install composer dependencies"
         run: |
-          composer install --no-ansi --no-interaction --no-progress --no-suggest
+          composer selfupdate --1
+          composer install --no-ansi --no-interaction --no-progress
           composer show
       - name: "Run tests"
         run: "composer ci:tests:functional"


### PR DESCRIPTION
As long as we are compatible with PHP 7.1, we need to keep using
an old version of `infection/infection` and cannot use Composer 2
with that.