### PR TITLE
[BUGFIX] Do not update packages on CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install composer dependencies"
         run: |
-          composer update --no-ansi --no-interaction --no-progress
+          composer install --no-ansi --no-interaction --no-progress
           composer show
       - name: "Run tests"
         run: "composer ci:tests:unit"
@@ -90,7 +90,7 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install composer dependencies"
         run: |
-          composer update --no-ansi --no-interaction --no-progress
+          composer install --no-ansi --no-interaction --no-progress
           composer show
       - name: "Run tests"
         run: "composer ci:tests:functional"


### PR DESCRIPTION
Now that we have a `composer.lock`, we need to use `composer install`, not `composer update` on CI anymore.