### PR TITLE
[BUGFIX] Properly quote the PHP versions in the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
-          - 8.0
+          - '7.4'
+          - '8.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,8 +36,8 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
-          - 8.0
+          - '7.4'
+          - '8.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,8 +69,8 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
-          - 8.0
+          - '7.4'
+          - '8.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This avoids that version 8.0 gets changed to "8".